### PR TITLE
Support overlay configs

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,11 +17,12 @@ var (
 	flagFunc = flag.String("func", "Fuzz", "fuzzer entry point")
 	flagO    = flag.String("o", "", "output file")
 
-	flagRace = flag.Bool("race", false, "enable data race detection")
-	flagTags = flag.String("tags", "", "a comma-separated list of build tags to consider satisfied during the build")
-	flagV    = flag.Bool("v", false, "print the names of packages as they are compiled")
-	flagWork = flag.Bool("work", false, "print the name of the temporary work directory and do not remove it when exiting")
-	flagX    = flag.Bool("x", false, "print the commands")
+	flagRace    = flag.Bool("race", false, "enable data race detection")
+	flagTags    = flag.String("tags", "", "a comma-separated list of build tags to consider satisfied during the build")
+	flagV       = flag.Bool("v", false, "print the names of packages as they are compiled")
+	flagWork    = flag.Bool("work", false, "print the name of the temporary work directory and do not remove it when exiting")
+	flagX       = flag.Bool("x", false, "print the commands")
+	flagOverlay = flag.String("overlay", "", "JSON config file that provides an overlay for build operations")
 )
 
 func main() {
@@ -117,6 +118,9 @@ func main() {
 	}
 
 	args := []string{"build", "-o", out}
+	if *flagOverlay != "" {
+		buildFlags = append(buildFlags, "-overlay", *flagOverlay)
+	}
 	args = append(args, buildFlags...)
 	args = append(args, mainFile.Name())
 	cmd := exec.Command("go", args...)


### PR DESCRIPTION
Tools that perform source-to-source translation often generate overlay JSON files that provide replacements for instrumented files. This way go build can use the instrumented source files without having to pollute the original code base.