### PR TITLE
Add support for rejecting unwanted inputs

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,10 +146,12 @@ import "C"
 
 //export LLVMFuzzerTestOneInput
 func LLVMFuzzerTestOneInput(data *C.char, size C.size_t) C.int {
-	// TODO(mdempsky): Use unsafe.Slice once golang.org/issue/19367 is accepted.
+	// Is faster than unsafe.Slice
 	s := (*[1<<30]byte)(unsafe.Pointer(data))[:size:size]
-	target.{{.Func}}(s)
-	return 0
+	if target.{{.Func}}(s) >= 0 {
+		return 0
+	}
+	return -1
 }
 
 func main() {


### PR DESCRIPTION
This was added in LLVM 15 (https://github.com/llvm/llvm-project/commit/92fb310151d2b1e349695fc0f1c5d5d50afb3b52). See https://llvm.org/docs/LibFuzzer.html#rejecting-unwanted-inputs for more information. The condition ensures compatibility with go-fuzz tests